### PR TITLE
Toggle documentation

### DIFF
--- a/toggle/README.md
+++ b/toggle/README.md
@@ -6,9 +6,9 @@
 2. [Install](#install)
 3. [Usage](#usage)
 4. [API](#api)
-   i. [Attributes](#api-attributes)
-   ii. [Properties](#api-properties)
-   iii. [Events](#api-events)
+    i. [Attributes](#api-attributes)
+    ii. [Properties](#api-properties)
+    iii. [Events](#api-events)
 
 A shareable, accessible toggle.
 

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -8,7 +8,6 @@
    1. [Semantics](#usage-semantics)
 4. [API](#api)
    1. [Attributes](#api-attributes)
-   2. [Properties](#api-properties)
    3. [Events](#api-events)
 
 A shareable, accessible toggle.
@@ -64,10 +63,11 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 `pearson-toggle`'s API is similar to that of an `input type="checkbox"`. You _must_ give it a unique ID, and you _must_ label it. That means either creating a `label` tag somewhere in the DOM and setting its `for` attribute to the ID of the toggle, wrapping the toggle in a label, or giving the toggle an `aria-label` attribute. When the toggle is triggered, it will emit a `change` event.
 
+All of the attributes in `pearson-toggle`'s API are reflected as _properties_. All of these can be accessed in JavaScript.
+
 <a name="api-attributes"></a>
 
 ### Attributes
-
 | Attribute  | Type      | Default  | Description                               |
 | ---------- | --------- | -------- | ----------------------------------------- |
 | `id`       | `String`  | Required | The unique ID of the toggle               |
@@ -77,42 +77,6 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 | `value`    | `String`  | unset    | The value of the toggle                   |
 
 <a name="api-attributes-example"></a>
-
-#### Example
-
-```html
-<pearson-toggle
-  id="textNotifications"
-  name="notifications"
-  value="text"
->
-</pearson-toggle>
-<label for="textNotifications">Text notifications</label>
-
-<pearson-toggle
-  id="emailNotifications"
-  name="notifications"
-  value="email"
-  on
->
-</pearson-toggle>
-<label for="emailNotifications">Email notifications</label>
-```
-
-<a name="api-properties"></a>
-
-### Properties
-
-Like native checkboxes, `pearson-toggle` exposes its `name` and `value` attributes as _properties_. It also exposes an `on` property to represent its state as an on/off switch. All of these can be easily accessed in JavaScript.
-
-| Property   | Type      | Description                      |
-| ---------- | --------- | -------------------------------- |
-| `name`     | `String`  | The name of the toggle           |
-| `value`    | `String`  | The value of the toggle          |
-| `on`       | `Boolean` | The on state of the toggle       |
-| `disabled` | `Boolean` | The disabled state of the toggle |
-
-<a name="api-properties-example"></a>
 
 #### Example
 
@@ -138,6 +102,9 @@ console.log(emailToggle.on); // true
 console.log(emailToggle.disabled); // false
 console.log(emailToggle.value); // 'email'
 console.log(emailToggle.name); // 'notifications'
+
+emailToggle.on = false;
+console.log(emailToggle.on); // false
 ```
 
 <a name="api-events"></a>

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -6,9 +6,9 @@
 2. [Install](#install)
 3. [Usage](#usage)
 4. [API](#api)
-    1. [Attributes](#api-attributes)
-    2. [Properties](#api-properties)
-    3. [Events](#api-events)
+   1. [Attributes](#api-attributes)
+   2. [Properties](#api-properties)
+   3. [Events](#api-events)
 
 A shareable, accessible toggle.
 
@@ -66,11 +66,11 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 | Attribute  | Type      | Default  | Description                                |
 | ---------- | --------- | -------- | ------------------------------------------ |
-| `id`       | `String`  | Required | The unique ID of the toggle.               |
-| `checked`  | `boolean` | `false`  | Determines whether the toggle is checked.  |
-| `disabled` | `boolean` | `false`  | Determines whether the toggle is disabled. |
-| `name`     | `String`  | unset    | The name of the toggle.                    |
-| `value`    | `String`  | unset    | The value of the toggle.                   |
+| `id`       | `String`  | Required | The unique ID of the toggle               |
+| `on`       | `boolean` | `false`  | Determines whether the toggle is on       |
+| `disabled` | `boolean` | `false`  | Determines whether the toggle is disabled |
+| `name`     | `String`  | unset    | The name of the toggle                    |
+| `value`    | `String`  | unset    | The value of the toggle                   |
 
 <a name="api-attributes-example"></a>
 
@@ -89,7 +89,7 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
   id="emailNotifications"
   name="notifications"
   value="email"
-  checked
+  on
 >
 </pearson-toggle>
 <label for="emailNotifications">Email notifications</label>
@@ -99,13 +99,13 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 ### Properties
 
-Like native checkboxes, `pearson-toggle` exposes its `name`, `value`, and `checked` attributes as _properties_, which can be easily accessed in JavaScript.
+Like native checkboxes, `pearson-toggle` exposes its `name`, `value`, and `on` attributes as _properties_, which can be easily accessed in JavaScript.
 
-| Property  | Type      | Description                      |
-| --------- | --------- | -------------------------------- |
-| `name`    | `String`  | The name of the toggle.          |
-| `value`   | `String`  | The value of the toggle.         |
-| `checked` | `Boolean` | The checked state of the toggle. |
+| Property | Type      | Description                 |
+| -------- | --------- | --------------------------- |
+| `name`   | `String`  | The name of the toggle     |
+| `value`  | `String`  | The value of the toggle    |
+| `on`     | `Boolean` | The on state of the toggle |
 
 **Important Note:**
 
@@ -122,7 +122,7 @@ HTML:
   id="emailNotifications"
   name="notifications"
   value="email"
-  checked
+  on
 >
 </pearson-toggle>
 <label for="emailNotifications">Email notifications</label>
@@ -134,7 +134,7 @@ JS:
 const emailToggle = document.querySelector('#emailNotifications');
 
 console.log(emailToggle.value); // 'email'
-console.log(emailToggle.checked); // true
+console.log(emailToggle.on); // true
 console.log(emailToggle.name); // 'notifications'
 ```
 
@@ -144,7 +144,7 @@ console.log(emailToggle.name); // 'notifications'
 
 | Event    | Description                                                   |
 | -------- | ------------------------------------------------------------- |
-| `change` | Will fire when the toggle is triggered via mouse or keyboard. |
+| `change` | Will fire when the toggle is triggered via mouse or keyboard |
 
 <a name="api-events-example"></a>
 
@@ -157,7 +157,7 @@ HTML:
   id="emailNotifications"
   name="notifications"
   value="email"
-  checked
+  on
 >
 </pearson-toggle>
 <label for="emailNotifications">Email notifications</label>
@@ -175,7 +175,7 @@ toggles.forEach(toggle => {
 
     // True or false, depending on how many times
     // the toggle has been clicked
-    console.log(self.checked);
+    console.log(self.on);
   });
 });
 ```

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -5,6 +5,7 @@
 1. [Demo](#demo)
 2. [Install](#install)
 3. [Usage](#usage)
+   1. [Semantics](#usage-semantics)
 4. [API](#api)
    1. [Attributes](#api-attributes)
    2. [Properties](#api-properties)
@@ -47,12 +48,15 @@ Import the web component onto the page, inbetween the `<head>` tags, like so:
 
 **Important Note:**
 
-> The import path will be in the **node_modules** folder, which is
-> usually held outside the applicaiton source. If you publish your
-> application to a **./public** or **./dist** folder you will want to
-> write a script to copy this dependency to a desired location.
+> The import path will be in the **node_modules** folder, which is usually held outside the applicaiton source. If you publish your application to a **./public** or **./dist** folder you will want to write a script to copy this dependency to a desired location.
 
 Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
+
+<a name="usage-semantics"></a>
+
+### Semantics
+
+[Switches are for instantaneous actions](http://uxmovement.com/buttons/when-to-use-a-switch-or-checkbox/). As soon as `pearson-toggle` fires its `change` event, the change it controls should be carried out. If you want the changes to be batched for form submission or another later action, you should not use `pearson-toggle`. `pearson-toggle` _will not_ send its `name` and `value` as part of a form `submit` event, so you will need to handle changes immediately anyway.
 
 <a name="api"></a>
 
@@ -106,10 +110,6 @@ Like native checkboxes, `pearson-toggle` exposes its `name` and `value` attribut
 | `name`   | `String`  | The name of the toggle     |
 | `value`  | `String`  | The value of the toggle    |
 | `on`     | `Boolean` | The on state of the toggle |
-
-**Important Note:**
-
-> _Unlike_ native checkboxes, `pearson-toggle` _will not_ send its `name` and `value` as part of a form `submit` event. If you need the value of a `pearson-toggle` at the time of form submission, you will have to use JavaScript to access it.
 
 <a name="api-properties-example"></a>
 

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -99,7 +99,7 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 ### Properties
 
-Like native checkboxes, `pearson-toggle` exposes its `name`, `value`, and `on` attributes as _properties_, which can be easily accessed in JavaScript.
+Like native checkboxes, `pearson-toggle` exposes its `name` and `value` attributes as _properties_. It also exposes an `on` property to represent its state as an on/off switch. All of these can be easily accessed in JavaScript.
 
 | Property | Type      | Description                |
 | -------- | --------- | -------------------------- |

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -6,9 +6,9 @@
 2. [Install](#install)
 3. [Usage](#usage)
 4. [API](#api)
-    i. [Attributes](#api-attributes)
-    ii. [Properties](#api-properties)
-    iii. [Events](#api-events)
+    1. [Attributes](#api-attributes)
+    2. [Properties](#api-properties)
+    3. [Events](#api-events)
 
 A shareable, accessible toggle.
 

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -64,8 +64,8 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 ### Attributes
 
-| Attribute  | Type      | Default  | Description                                |
-| ---------- | --------- | -------- | ------------------------------------------ |
+| Attribute  | Type      | Default  | Description                               |
+| ---------- | --------- | -------- | ----------------------------------------- |
 | `id`       | `String`  | Required | The unique ID of the toggle               |
 | `on`       | `boolean` | `false`  | Determines whether the toggle is on       |
 | `disabled` | `boolean` | `false`  | Determines whether the toggle is disabled |
@@ -101,8 +101,8 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 Like native checkboxes, `pearson-toggle` exposes its `name`, `value`, and `on` attributes as _properties_, which can be easily accessed in JavaScript.
 
-| Property | Type      | Description                 |
-| -------- | --------- | --------------------------- |
+| Property | Type      | Description                |
+| -------- | --------- | -------------------------- |
 | `name`   | `String`  | The name of the toggle     |
 | `value`  | `String`  | The value of the toggle    |
 | `on`     | `Boolean` | The on state of the toggle |
@@ -142,8 +142,8 @@ console.log(emailToggle.name); // 'notifications'
 
 ### Emitted Events
 
-| Event    | Description                                                   |
-| -------- | ------------------------------------------------------------- |
+| Event    | Description                                                  |
+| -------- | ------------------------------------------------------------ |
 | `change` | Will fire when the toggle is triggered via mouse or keyboard |
 
 <a name="api-events-example"></a>

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -105,11 +105,12 @@ Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
 
 Like native checkboxes, `pearson-toggle` exposes its `name` and `value` attributes as _properties_. It also exposes an `on` property to represent its state as an on/off switch. All of these can be easily accessed in JavaScript.
 
-| Property | Type      | Description                |
-| -------- | --------- | -------------------------- |
-| `name`   | `String`  | The name of the toggle     |
-| `value`  | `String`  | The value of the toggle    |
-| `on`     | `Boolean` | The on state of the toggle |
+| Property   | Type      | Description                      |
+| ---------- | --------- | -------------------------------- |
+| `name`     | `String`  | The name of the toggle           |
+| `value`    | `String`  | The value of the toggle          |
+| `on`       | `Boolean` | The on state of the toggle       |
+| `disabled` | `Boolean` | The disabled state of the toggle |
 
 <a name="api-properties-example"></a>
 
@@ -133,8 +134,9 @@ JS:
 ```js
 const emailToggle = document.querySelector('#emailNotifications');
 
-console.log(emailToggle.value); // 'email'
 console.log(emailToggle.on); // true
+console.log(emailToggle.disabled); // false
+console.log(emailToggle.value); // 'email'
 console.log(emailToggle.name); // 'notifications'
 ```
 

--- a/toggle/README.md
+++ b/toggle/README.md
@@ -1,34 +1,181 @@
+# Pearson Toggle Web Component
 
-# Web Component Spec Kit
-A simple web component example to help you convert your existing HTML into a web component.
+## Table of Contents
 
-## Get Started
-Download this kit as a zipfile and place in your web components folder, to use this as a starting point to convert your markup from the markup kit to a web component.  This kit has the following
+1. [Demo](#demo)
+2. [Install](#install)
+3. [Usage](#usage)
+4. [API](#api)
+   i. [Attributes](#api-attributes)
+   ii. [Properties](#api-properties)
+   iii. [Events](#api-events)
 
- - An example.html file that includes all the recommended polyfills and loads an existing web component
- - An index.html file that includes example markup for an HTML template.
- -  A main.js file that includes a basic scripting example for shadow dom.
- - Babel to compile your main.js file so its compatible with IE11
- -  SCSS compatibility
+A shareable, accessible toggle.
 
-Once your ready, install the dependancies:
+<a name="demo"></a>
 
-    npm install
+## Demo
 
-<br>
+https://pearson-ux.github.io/web-components/toggle/example.html
 
-**Basic commands to get you started:** 
+<a name="install"></a>
 
-Compile scss
+## Installation
 
-    gulp styles
+Make sure you have all the appropriate polyfills from [the main README](https://github.com/pearson-ux/web-components/blob/master/README.md) in place. Then, run the following in your terminal:
 
-Run babel
+```bash
+# my-app is the directory containing your app
+cd my-app
+npm install --save @pearson-ux/toggle
+```
 
-    gulp babel
+<a name="usage"></a>
 
-Watch for changes
+## Usage
 
-    gulp watch
+Import the web component onto the page, inbetween the `<head>` tags, like so:
 
+```html
+<head>
+  <!-- polyfills and other stuff... -->
 
+  <!-- import web components -->
+  <link rel="import" href="/path/to/toggle/index.html" />
+</head>
+```
+
+**Important Note:**
+
+> The import path will be in the **node_modules** folder, which is
+> usually held outside the applicaiton source. If you publish your
+> application to a **./public** or **./dist** folder you will want to
+> write a script to copy this dependency to a desired location.
+
+Add the `<pearson-toggle> </pearson-toggle>` tags to the page.
+
+<a name="api"></a>
+
+## API
+
+`pearson-toggle`'s API is similar to that of an `input type="checkbox"`. You _must_ give it a unique ID, and you _must_ label it. That means either creating a `label` tag somewhere in the DOM and setting its `for` attribute to the ID of the toggle, wrapping the toggle in a label, or giving the toggle an `aria-label` attribute. When the toggle is triggered, it will emit a `change` event.
+
+<a name="api-attributes"></a>
+
+### Attributes
+
+| Attribute  | Type      | Default  | Description                                |
+| ---------- | --------- | -------- | ------------------------------------------ |
+| `id`       | `String`  | Required | The unique ID of the toggle.               |
+| `checked`  | `boolean` | `false`  | Determines whether the toggle is checked.  |
+| `disabled` | `boolean` | `false`  | Determines whether the toggle is disabled. |
+| `name`     | `String`  | unset    | The name of the toggle.                    |
+| `value`    | `String`  | unset    | The value of the toggle.                   |
+
+<a name="api-attributes-example"></a>
+
+#### Example
+
+```html
+<pearson-toggle
+  id="textNotifications"
+  name="notifications"
+  value="text"
+>
+</pearson-toggle>
+<label for="textNotifications">Text notifications</label>
+
+<pearson-toggle
+  id="emailNotifications"
+  name="notifications"
+  value="email"
+  checked
+>
+</pearson-toggle>
+<label for="emailNotifications">Email notifications</label>
+```
+
+<a name="api-properties"></a>
+
+### Properties
+
+Like native checkboxes, `pearson-toggle` exposes its `name`, `value`, and `checked` attributes as _properties_, which can be easily accessed in JavaScript.
+
+| Property  | Type      | Description                      |
+| --------- | --------- | -------------------------------- |
+| `name`    | `String`  | The name of the toggle.          |
+| `value`   | `String`  | The value of the toggle.         |
+| `checked` | `Boolean` | The checked state of the toggle. |
+
+**Important Note:**
+
+> _Unlike_ native checkboxes, `pearson-toggle` _will not_ send its `name` and `value` as part of a form `submit` event. If you need the value of a `pearson-toggle` at the time of form submission, you will have to use JavaScript to access it.
+
+<a name="api-properties-example"></a>
+
+#### Example
+
+HTML:
+
+```html
+<pearson-toggle
+  id="emailNotifications"
+  name="notifications"
+  value="email"
+  checked
+>
+</pearson-toggle>
+<label for="emailNotifications">Email notifications</label>
+```
+
+JS:
+
+```js
+const emailToggle = document.querySelector('#emailNotifications');
+
+console.log(emailToggle.value); // 'email'
+console.log(emailToggle.checked); // true
+console.log(emailToggle.name); // 'notifications'
+```
+
+<a name="api-events"></a>
+
+### Emitted Events
+
+| Event    | Description                                                   |
+| -------- | ------------------------------------------------------------- |
+| `change` | Will fire when the toggle is triggered via mouse or keyboard. |
+
+<a name="api-events-example"></a>
+
+#### Example
+
+HTML:
+
+```html
+<pearson-toggle
+  id="emailNotifications"
+  name="notifications"
+  value="email"
+  checked
+>
+</pearson-toggle>
+<label for="emailNotifications">Email notifications</label>
+```
+
+JS:
+
+```js
+const toggles = document.querySelectorAll('pearson-toggle');
+
+toggles.forEach(toggle => {
+  toggle.addEventListener('change', e => {
+    // This toggle
+    const self = e.target;
+
+    // True or false, depending on how many times
+    // the toggle has been clicked
+    console.log(self.checked);
+  });
+});
+```


### PR DESCRIPTION
[Rendered markdown](https://github.com/pearson-ux/web-components/blob/efbb88a347a021258956649f80781cc5f4ebf260/toggle/README.md)

One noteworthy thing, @antelopeb - this comment on semantics:
> [Switches are for instantaneous actions](http://uxmovement.com/buttons/when-to-use-a-switch-or-checkbox/). As soon as `pearson-toggle` fires its `change` event, the change it controls should be carried out. If you want the changes to be batched for form submission or another later action, you should not use `pearson-toggle`. `pearson-toggle` _will not_ send its `name` and `value` as part of a form `submit` event, so you will need to handle changes immediately anyway.

Dave mentioned that designers at Pearson use switches incorrectly. Hopefully the mechanical limitation of custom elements will stop them. lol