### PR TITLE
Alert: `dismiss` event

### DIFF
--- a/alert/example.html
+++ b/alert/example.html
@@ -71,10 +71,6 @@
 						'  </p>  '
 					);
 
-					alert.addEventListener('dismiss', function (e) {
-						renderMessage(e.target);
-					});
-		
 					if (type === 'inline') {
 						doc.body.insertBefore(alert, e.target.nextSibling)
 					} else {
@@ -89,6 +85,10 @@
 				forEach.call(triggers, function (trigger) {
 					trigger.addEventListener('click', triggerAlert);
 				})
+
+				w.addEventListener('dismiss', function (e) {
+					renderMessage(e.target);
+				});
 				
 			})(window, document);
 		</script>

--- a/alert/example.html
+++ b/alert/example.html
@@ -17,7 +17,11 @@
 	<!-- import web components -->
 	<link rel="import" href="index.html" />
 
-
+<style>
+.output {
+	margin-top: 5rem;
+}
+</style>
 </head>
 
 <body>
@@ -30,12 +34,13 @@
 	<button id="trigger-2" data-trigger="alert" data-severity="important" data-type="global">
 		Trigger global important alert
 	</button>
-
+	<div id="output" class="output" aria-live="polite" aria-atomic="true"></div>
 	<script>
 			(function (w, doc) {
 				const forEach = Array.prototype.forEach;
 				const triggers = doc
 					.querySelectorAll('button[data-trigger="alert"]');
+				const statusRegion = doc.querySelector('#output');
 		
 				function generateAlert(opts) {
 					const alert = doc.createElement('pearson-alert');
@@ -65,6 +70,10 @@
 						'     <a href="#">Something has happened!</a>  ' +
 						'  </p>  '
 					);
+
+					alert.addEventListener('dismiss', function (e) {
+						renderMessage(e.target);
+					});
 		
 					if (type === 'inline') {
 						doc.body.insertBefore(alert, e.target.nextSibling)
@@ -72,10 +81,15 @@
 						doc.body.appendChild(alert)
 					}
 				}
+
+				function renderMessage(alertElem) {
+					statusRegion.innerHTML = 'Closed ' + alertElem.severity + ' alert';
+				}
 		
 				forEach.call(triggers, function (trigger) {
 					trigger.addEventListener('click', triggerAlert);
 				})
+				
 			})(window, document);
 		</script>
 

--- a/alert/js/dist/main.js
+++ b/alert/js/dist/main.js
@@ -83,10 +83,6 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
       value: function disconnectedCallback() {
         var returnNode = this._findReturnNode();
 
-        this.dispatchEvent(new Event('dismiss', {
-          bubbles: true
-        }));
-
         this.alert.removeEventListener('animationend', this._onAnimationEnd);
         this.closeBtn.removeEventListener('click', this._onClose);
 
@@ -101,6 +97,10 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
         if (this.type === 'inline') {
           this.alert.classList.add('fadeOut');
         }
+
+        this.dispatchEvent(new Event('dismiss', {
+          bubbles: true
+        }));
       }
     }, {
       key: '_onAnimationEnd',

--- a/alert/js/dist/main.js
+++ b/alert/js/dist/main.js
@@ -83,6 +83,10 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
       value: function disconnectedCallback() {
         var returnNode = this._findReturnNode();
 
+        this.dispatchEvent(new Event('dismiss', {
+          bubbles: true
+        }));
+
         this.alert.removeEventListener('animationend', this._onAnimationEnd);
         this.closeBtn.removeEventListener('click', this._onClose);
 

--- a/alert/js/main.js
+++ b/alert/js/main.js
@@ -67,12 +67,6 @@
     disconnectedCallback() {
       const returnNode = this._findReturnNode();
 
-      this.dispatchEvent(
-        new Event('dismiss', {
-          bubbles: true
-        })
-      );
-
       this.alert.removeEventListener('animationend', this._onAnimationEnd);
       this.closeBtn.removeEventListener('click', this._onClose);
       
@@ -86,6 +80,12 @@
       if (this.type === 'inline') {
         this.alert.classList.add('fadeOut');
       }
+      
+      this.dispatchEvent(
+        new Event('dismiss', {
+          bubbles: true
+        })
+      );
     }
 
     _onAnimationEnd(e) {

--- a/alert/js/main.js
+++ b/alert/js/main.js
@@ -67,6 +67,12 @@
     disconnectedCallback() {
       const returnNode = this._findReturnNode();
 
+      this.dispatchEvent(
+        new Event('dismiss', {
+          bubbles: true
+        })
+      );
+
       this.alert.removeEventListener('animationend', this._onAnimationEnd);
       this.closeBtn.removeEventListener('click', this._onClose);
       


### PR DESCRIPTION
Whenever an alert is closed, it emits a `dismiss` event.

Interesting potential limitation, @antelopeb: shadow dom events don't seem to bubble up through light DOM. listening for `dismiss` on the window does nothing; it never gets there.