### PR TITLE
Fix: allow consumer to determine which button opens drawer

### DIFF
--- a/drawer/details.html
+++ b/drawer/details.html
@@ -23,7 +23,7 @@
 
   <body>  
     <main>
-      <button type="button" id="pearsonDrawerTrigger">
+      <button type="button" for="pearsonDrawer">
         Open details drawer
       </button>
     </main>
@@ -172,8 +172,8 @@
       </div>
     </pearson-drawer>
     <script>
-      const openBtn = document.querySelector('#pearsonDrawerTrigger');
-      const drawer = document.querySelector('#pearsonDrawer');
+    const openBtn = document.querySelector('[for="pearsonDrawer"]');
+    const drawer = document.querySelector('#pearsonDrawer');
 
       openBtn.addEventListener('click', function(e) {
         drawer.open = true;

--- a/drawer/js/dist/pearson-drawer.js
+++ b/drawer/js/dist/pearson-drawer.js
@@ -135,7 +135,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
       _this.shadowRoot.appendChild(clone);
 
-      _this.trigger = doc.querySelector('#pearsonDrawerTrigger');
+      _this.trigger = doc.querySelector('[for="' + _this.id + '"]');
 
       _this.onContentScroll = _this.onContentScroll.bind(_this);
       _this.onTitleSlotChange = _this.onTitleSlotChange.bind(_this);

--- a/drawer/js/pearson-drawer.js
+++ b/drawer/js/pearson-drawer.js
@@ -178,7 +178,7 @@
 
       this.shadowRoot.appendChild(clone);
 
-      this.trigger = doc.querySelector('#pearsonDrawerTrigger');
+      this.trigger = doc.querySelector(`[for="${this.id}"]`);
 
       this.onContentScroll = this.onContentScroll.bind(this);
       this.onTitleSlotChange = this.onTitleSlotChange.bind(this);

--- a/drawer/standard.html
+++ b/drawer/standard.html
@@ -20,7 +20,7 @@
 
   <body>
     <main>
-      <button type="button" id="pearsonDrawerTrigger">Open standard drawer</button>
+      <button type="button" for="pearsonDrawer">Open standard drawer</button>
     </main>
     <pearson-drawer id="pearsonDrawer">
       <h3 slot="title" class="title">Help Topics</h3>
@@ -33,7 +33,7 @@
       </div>
     </pearson-drawer>
     <script>
-    const openBtn = document.querySelector('#pearsonDrawerTrigger');
+    const openBtn = document.querySelector('[for="pearsonDrawer"]');
     const drawer = document.querySelector('#pearsonDrawer');
 
     openBtn.addEventListener('click', function (e) {


### PR DESCRIPTION
This change allows the user to associate the trigger to the drawer by applying a `for` attribute to the drawer. The button's `for` must match the ID of a drawer. Example:
``` html
<button for="pearsonDrawer">Open drawer</button>
<pearson-drawer id="pearsonDrawer">
  <!-- content.... -->
</pearson-drawer>
```